### PR TITLE
Fetch discord online stats with a proxy

### DIFF
--- a/discord/discord.py
+++ b/discord/discord.py
@@ -16,8 +16,10 @@ except ImportError:
     raise
 
 # Set up where we'll be fetching data from
-DATA_SOURCE = "https://img.shields.io/discord/327254708534116352.svg"
-DATA_LOCATION = ["svg"]
+# A very simple glitch.com proxy to massage the Discord widget data!
+# Source is at: https://glitch.com/~gamy-scissor
+DATA_SOURCE = "https://gamy-scissor.glitch.me/327254708534116352/online.json"
+DATA_LOCATION = ["members","total"]
 
 cwd = __file__.rsplit('/', 1)[0]
 pyportal = adafruit_pyportal.PyPortal(url=DATA_SOURCE, json_path=DATA_LOCATION,

--- a/discord/discord.py
+++ b/discord/discord.py
@@ -17,8 +17,8 @@ except ImportError:
 
 # Set up where we'll be fetching data from
 # A very simple glitch.com proxy to massage the Discord widget data!
-# Source is at: https://glitch.com/~gamy-scissor
-DATA_SOURCE = "https://gamy-scissor.glitch.me/327254708534116352/online.json"
+# Source is at: https://glitch.com/~discord-widget-aggregated
+DATA_SOURCE = "https://discord-widget-aggregated.glitch.me/327254708534116352/online.json"
 DATA_LOCATION = ["members","total"]
 
 cwd = __file__.rsplit('/', 1)[0]


### PR DESCRIPTION
Discord has a widget to view the online membership stats of any Discord server. Here's Adafruit's:

https://discordapp.com/api/servers/327254708534116352/widget.json

It has a gigantic `members` list with the details and status of everyone signed in to the server.

I spent a good amount of time goofing with trying to port a streaming JSON-parser to read the ~500kb result and I just don't have the know-how at this time.

So, I wrote a very simple nodeJS proxy on glitch.com that rolls up the long individual `members` list into totals by status: `dnd`, `idle`, `online`, and `total` for a grand total.

Source is here: https://glitch.com/~discord-gadget-aggregated

Example for Adafruit: https://discord-widget-aggregated.glitch.me/327254708534116352/online.json

![ddd8f1ed940aee3dcad86ee65464a650bb2fead7cc8edae0e69c111c](https://user-images.githubusercontent.com/14772/52828431-c3d11d00-3096-11e9-8a0c-48831c8ea4a3.jpg)
